### PR TITLE
Fixes & suggestions to package structure

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-RAPNET_AUTH_URL="https://rapaport-prod.auth0.com"
-RAPNET_GATEWAY_BASE_URL="https://technet.rapnetapis.com"
-RAPNET_MACHINE_TO_MACHINE_AUTH_URL="https://authztoken.api.rapaport.com"
-RAPNET_GATEWAY_AUDIENCE="https://instantinventory.rapnetapis.com"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 /vendor/
-.env
-/storage/*

--- a/composer.json
+++ b/composer.json
@@ -11,24 +11,7 @@
     "require": {
         "php": ">=7.2.5",
         "guzzlehttp/guzzle": "^7.3",
-        "vlucas/phpdotenv": "^5.4.0",
         "caseyamcl/guzzle_retry_middleware": "^2.8"
     },
-    "scripts": {        
-        "post-update-cmd": [
-            "@build-prod"
-        ],
-        "post-install-cmd": [
-            "@build-prod"
-        ],
-        "build-dev": [
-          "php -r \"copy('.env.local', '.env');\""  
-        ],
-        "build-stage": [
-          "php -r \"copy('.env.stage', '.env');\""  
-        ],
-        "build-prod": [
-          "php -r \"copy('.env.prod', '.env');\""  
-        ]
-    }
+    "scripts": {}
 }

--- a/src/Actions.php
+++ b/src/Actions.php
@@ -1,43 +1,51 @@
-<?php 
+<?php
 
 namespace Rapnet\RapnetPriceList;
 
 use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Exception\ClientException;
-
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Promise\Utils;
 use GuzzleHttp\HandlerStack;
 use GuzzleRetry\GuzzleRetryMiddleware;
 
-require('env.php');
-
-class Index {
-
+/**
+ * Class Actions
+ * Client for interacting with the RapNet API.
+ * @package Rapnet\RapnetPriceList
+ */
+class Actions
+{
     private $config;
 
-    public function __construct($clientId = null, $clientSecret = null) {
-        $this->config = 
-            [
-              'base_path' => $_ENV['RAPNET_GATEWAY_BASE_URL'],
-              'authorization_url' => $_ENV['RAPNET_AUTH_URL'],
-              'machine_auth_url' => $_ENV['RAPNET_MACHINE_TO_MACHINE_AUTH_URL'],
-              'client_id' => $clientId,
-              'client_secret' => $clientSecret,
-              'redirect_uri' => null,              
-              'token_callback' => null,
-              'pricelist_url' => $_ENV['RAPNET_GATEWAY_BASE_URL'].'/pricelist/api',
-              'jwt' => null,
-              'scope' => 'manageListings priceListWeekly instantInventory',
-              'audience' => 'https://pricelist.rapnetapis.com'
-            ];
+    /**
+     * Constructor for the Index class.
+     *
+     * @param string|null $clientId The client ID.
+     * @param string|null $clientSecret The client secret.
+     */
+    public function __construct($clientId = null, $clientSecret = null)
+    {
+        $this->config = [
+            'base_path' => "https://technet.rapnetapis.com",
+            'authorization_url' => "https://rapaport-prod.auth0.com",
+            'machine_auth_url' => "https://authztoken.api.rapaport.com",
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
+            'redirect_uri' => null,
+            'token_callback' => null,
+            'pricelist_url' => "https://technet.rapnetapis.com/pricelist/api",
+            'jwt' => null,
+            'scope' => 'manageListings priceListWeekly instantInventory',
+            'audience' => 'https://pricelist.rapnetapis.com'
+        ];
     }
 
-     public function authorize($redirectUrl)
+    /**
+     * Authorizes the user by redirecting to the authorization URL.
+     *
+     * @param string $redirectUrl The redirect URL.
+     */
+    public function authorize($redirectUrl)
     {
-
         $client = new GuzzleClient(['verify' => false]);
         $url = "{$this->config['authorization_url']}/authorize?response_type=code&client_id={$this->config['client_id']}&redirect_uri={$redirectUrl}&audience={$this->config['audience']}&scope={$this->config['scope']}";
 
@@ -45,6 +53,14 @@ class Index {
         exit();
     }
 
+    /**
+     * Retrieves an authentication token for user authentication.
+     *
+     * @param string $code The authorization code.
+     * @param string $redirectUrl The redirect URL.
+     * @return array|null The decoded authentication token data or null on failure.
+     * @throws RequestException if the API request fails.
+     */
     public function getAuthToken($code, $redirectUrl)
     {
         try {
@@ -57,7 +73,10 @@ class Index {
             $client = new GuzzleClient(['verify' => false, 'handler' => $stack]);
             $url = "{$this->config['machine_auth_url']}/api/get";
 
-            $response = $client->request('POST',  $url, [
+            $response = $client->request(
+                'POST',
+                $url,
+                [
                     'headers' => [
                         'Content-Type' => 'application/x-www-form-urlencoded'
                     ],
@@ -72,11 +91,23 @@ class Index {
             return json_decode($response->getBody());
         } catch (RequestException $e) {
             return $e->getMessage();
-        }        
+        }
     }
-    
 
+    // Added as an alias to fix the spelling mistake
     public function getAuthTokenMachineToMachinMethod()
+    {
+        // @deprecated Use getAuthTokenMachineToMachineMethod instead
+        return $this->getAuthTokenMachineToMachineMethod();
+    }
+
+    /**
+     * Retrieves an authentication token for machine-to-machine authentication.
+     *
+     * @return array|null The decoded authentication token data or null on failure.
+     * @throws RequestException if the API request fails.
+     */
+    public function getAuthTokenMachineToMachineMethod()
     {
         try {
             $stack = HandlerStack::create();
@@ -88,7 +119,10 @@ class Index {
             $client = new GuzzleClient(['verify' => false, 'handler' => $stack]);
             $url = "{$this->config['machine_auth_url']}/api/get";
 
-            $response = $client->request('GET',  $url, [
+            $response = $client->request(
+                'GET',
+                $url,
+                [
                     'headers' => [
                         'Content-Type' => 'application/json',
                     ],
@@ -101,15 +135,18 @@ class Index {
             return json_decode($response->getBody());
         } catch (RequestException $e) {
             return $e->getMessage();
-        }        
-    }   
+        }
+    }
 
-    
-    /*
-        'application/json'
-        'application/xml'
-        'application/dbf'
-    */
+    /**
+     * Retrieves the price list for a given shape.
+     *
+     * @param string $token The authorization token.
+     * @param string $shape The diamond shape (e.g., 'Round'). Defaults to 'Round'.
+     * @param string $acceptType The desired response format ('application/json', 'application/xml', 'application/dbf').
+     * @return array|null The decoded price list data or null on failure (consider throwing exception instead).
+     * @throws RequestException if the API request fails.
+     */
     public function getPricesList($token, $shape = 'Round', $acceptType = 'application/json')
     {
         try {
@@ -120,11 +157,11 @@ class Index {
             ]));
 
             $client = new GuzzleClient(['verify' => false, 'handler' => $stack]);
-            $url = "{$this->config['pricelist_url']}/Prices/list?shape={$shape}";            
+            $url = "{$this->config['pricelist_url']}/Prices/list?shape={$shape}";
 
             $response = $client->request('GET', $url, [
                 'headers' => [
-                    'accept' => "${acceptType}",
+                    'accept' => $acceptType,
                     'Content-Type' => 'application/json',
                     'authorization' => "Bearer {$token}"
                 ]
@@ -133,9 +170,18 @@ class Index {
             return json_decode($response->getBody());
         } catch (RequestException $e) {
             return $e->getMessage();
-        }        
-    }   
+        }
+    }
 
+    /**
+     * Retrieves the normalized price list for a given shape.
+     *
+     * @param string $token The authorization token.
+     * @param string $shape The diamond shape (e.g., 'Round'). Defaults to 'Round'.
+     * @param bool $csvnormalized Whether to return the price list in CSV format.
+     * @return array|null The decoded price list data or null on failure (consider throwing exception instead).
+     * @throws RequestException if the API request fails.
+     */
     public function getNormalizedPricesList($token, $shape = 'Round', $csvnormalized = true)
     {
         try {
@@ -146,7 +192,7 @@ class Index {
             ]));
 
             $client = new GuzzleClient(['verify' => false, 'handler' => $stack]);
-            $url = "{$this->config['pricelist_url']}/Prices/list?shape={$shape}&csvnormalized={$csvnormalized}";            
+            $url = "{$this->config['pricelist_url']}/Prices/list?shape={$shape}&csvnormalized={$csvnormalized}";
 
             $response = $client->request('GET', $url, [
                 'headers' => [
@@ -159,13 +205,21 @@ class Index {
             return json_decode($response->getBody());
         } catch (RequestException $e) {
             return $e->getMessage();
-        }        
+        }
     }
 
-    /*
-        'application/xml'
-    */
-
+    /**
+     * Retrieves price items for a given shape, size, color, and clarity.
+     *
+     * @param string $token The authorization token.
+     * @param string $shape The diamond shape (e.g., 'Round'). Defaults to 'Round'.
+     * @param string $size The size of the diamond.
+     * @param string $color The color of the diamond.
+     * @param string $clarity The clarity of the diamond.
+     * @param string $acceptType The desired response format ('application/json', 'application/xml').
+     * @return array|null The decoded price items data or null on failure (consider throwing exception instead).
+     * @throws RequestException if the API request fails.
+     */
     public function getPriceItems($token, $shape = 'Round', $size, $color, $clarity, $acceptType = 'application/json')
     {
         try {
@@ -180,7 +234,7 @@ class Index {
 
             $response = $client->request('GET', $url, [
                 'headers' => [
-                    'Accept' => "${acceptType}",
+                    'Accept' => $acceptType,
                     'Content-Type' => 'application/json',
                     'authorization' => "Bearer {$token}"
                 ]
@@ -189,9 +243,17 @@ class Index {
             return json_decode($response->getBody());
         } catch (RequestException $e) {
             return $e->getMessage();
-        }        
+        }
     }
-   
+
+    /**
+     * Retrieves price changes for a given shape.
+     *
+     * @param string $token The authorization token.
+     * @param string $shape The diamond shape (e.g., 'Round'). Defaults to 'Round'.
+     * @return array|null The decoded price changes data or null on failure (consider throwing exception instead).
+     * @throws RequestException if the API request fails.
+     */
     public function getPricesChanges($token, $shape = 'Round')
     {
         try {
@@ -200,7 +262,7 @@ class Index {
                 'max_retry_attempts' => 2,
                 'retry_on_status' => [429, 503, 500]
             ]));
-            
+
             $client = new GuzzleClient(['verify' => false, 'handler' => $stack]);
             $url = "{$this->config['pricelist_url']}/Prices/changes?shape={$shape}";
 
@@ -215,6 +277,6 @@ class Index {
             return json_decode($response->getBody());
         } catch (RequestException $e) {
             return $e->getMessage();
-        }        
+        }
     }
 }

--- a/src/env.php
+++ b/src/env.php
@@ -1,6 +1,0 @@
-<?php
-
-require_once(dirname(__DIR__, 4).'/vendor/autoload.php');
-
-$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__, 1), '.env');
-$dotenv->load();


### PR DESCRIPTION
Hit some issues when using this package today and figured someone else might in the future.

- I've removed the internal .env file and variables in place of just writing the strings out into the main class as only one of the variables was used more than once. Loading in dotenv for that felt redundant, especially as they're not secretive or required to be hidden as they're embedded in the repo anyway.
- Fixed the spelling of `getAuthTokenMachineToMachinMethod` while still allowing it with an alias.
- Most importantly, renamed `index.php` to `Actions.php`. linux being case sensitive meant that the class was never found in production while it worked fine in a local macos environment. But I landed on "Actions" over "Index" as it doesnt "Index" anything, but does contain multiple actions such as authentication and then fetching. Ideally each group of actions would be it's own class, but I honestly couldnt be bothered with that for now.
- Added docblock documentation to each method.
- Removed unused composer script actions.

These are all just my suggestions really and if actioned the documentation [here](https://raptech.rapaport.com/rapaport-developer-documentation/) will need updating. I suspect there's some crossover with other packages that could be resolved by just making one composer package with all of the classes individually within. 